### PR TITLE
The Sprite Yeet PR (ie safely remove sprites)

### DIFF
--- a/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
@@ -309,6 +309,18 @@ class BCCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BCCAD, i
 
     override fun removeSprite(sprite: ISprite) {
         if (sprite is Sprite) {
+            //TODO: check if there's no other steps in the animation, if so it can't delete it or has to delete the anim
+            val index = data.sprites.indexOf(sprite).toUShort()
+            for (anim in data.animations) {
+                for (step in anim.steps) {
+                    if (step.spriteIndex == index) {
+                        //TODO: prompt
+                        step.spriteIndex = 0.toUShort()
+                    } else if (step.spriteIndex > index) {
+                        step.spriteIndex = (step.spriteIndex - 1.toUShort()).toUShort()
+                    }
+                }
+            }
             data.sprites -= sprite
         }
     }
@@ -320,18 +332,6 @@ class BCCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BCCAD, i
     }
 
     override fun removeSpritePart(sprite: ISprite, part: ISpritePart) {
-        //TODO: check if there's no other steps in the animation, if so it can't delete it or has to delete the anim
-        val index = data.sprites.indexOf(sprite) as UShort
-        for (anim in data.animations) {
-            for (step in anim.steps) {
-                if (step.spriteIndex == index) {
-                    //TODO: prompt
-                    step.spriteIndex = 0 as UShort
-                } else if (step.spriteIndex > index) {
-                    step.spriteIndex = (step.spriteIndex - 1 as UShort) as UShort
-                }
-            }
-        }
         if (sprite is Sprite && part is SpritePart) {
             sprite.parts -= part
         }

--- a/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
@@ -309,12 +309,12 @@ class BCCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BCCAD, i
 
     override fun removeSprite(sprite: ISprite) {
         if (sprite is Sprite) {
-            //TODO: check if there's no other steps in the animation, if so it can't delete it or has to delete the anim
             val index = data.sprites.indexOf(sprite).toUShort()
+
+            // Now that we've done all the checking, time for the actual replacing
             for (anim in data.animations) {
                 for (step in anim.steps) {
                     if (step.spriteIndex == index) {
-                        //TODO: prompt
                         step.spriteIndex = 0.toUShort()
                     } else if (step.spriteIndex > index) {
                         step.spriteIndex = (step.spriteIndex - 1.toUShort()).toUShort()

--- a/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
@@ -320,6 +320,18 @@ class BCCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BCCAD, i
     }
 
     override fun removeSpritePart(sprite: ISprite, part: ISpritePart) {
+        //TODO: check if there's no other steps in the animation, if so it can't delete it
+        val index = data.sprites.indexOf(sprite) as UShort
+        for (anim in data.animations) {
+            for (step in anim.steps) {
+                if (step.spriteIndex == index) {
+                    //TODO: prompt
+                    step.spriteIndex = 0 as UShort
+                } else if (step.spriteIndex > index) {
+                    step.spriteIndex = (step.spriteIndex - 1 as UShort) as UShort
+                }
+            }
+        }
         if (sprite is Sprite && part is SpritePart) {
             sprite.parts -= part
         }

--- a/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
@@ -311,7 +311,6 @@ class BCCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BCCAD, i
         if (sprite is Sprite) {
             val index = data.sprites.indexOf(sprite).toUShort()
 
-            // Now that we've done all the checking, time for the actual replacing
             for (anim in data.animations) {
                 for (step in anim.steps) {
                     if (step.spriteIndex == index) {

--- a/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BCCADEditor.kt
@@ -320,7 +320,7 @@ class BCCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BCCAD, i
     }
 
     override fun removeSpritePart(sprite: ISprite, part: ISpritePart) {
-        //TODO: check if there's no other steps in the animation, if so it can't delete it
+        //TODO: check if there's no other steps in the animation, if so it can't delete it or has to delete the anim
         val index = data.sprites.indexOf(sprite) as UShort
         for (anim in data.animations) {
             for (step in anim.steps) {

--- a/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
@@ -158,6 +158,18 @@ class BRCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BRCAD, i
     
     override fun removeSprite(sprite: ISprite) {
         if (sprite is Sprite) {
+            //TODO: check if there's no other steps in the animation, if so it can't delete it
+            val index = data.sprites.indexOf(sprite) as UShort
+            for (anim in data.animations) {
+                for (step in anim.steps) {
+                    if (step.spriteIndex == index) {
+                        //TODO: prompt
+                        step.spriteIndex = 0 as UShort
+                    } else if (step.spriteIndex > index) {
+                        step.spriteIndex = (step.spriteIndex - 1 as UShort) as UShort
+                    }
+                }
+            }
             data.sprites -= sprite
         }
     }

--- a/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
@@ -158,7 +158,7 @@ class BRCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BRCAD, i
     
     override fun removeSprite(sprite: ISprite) {
         if (sprite is Sprite) {
-            //TODO: check if there's no other steps in the animation, if so it can't delete it
+            //TODO: check if there's no other steps in the animation, if so it can't delete it or has to delete the anim
             val index = data.sprites.indexOf(sprite) as UShort
             for (anim in data.animations) {
                 for (step in anim.steps) {

--- a/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
@@ -158,12 +158,12 @@ class BRCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BRCAD, i
     
     override fun removeSprite(sprite: ISprite) {
         if (sprite is Sprite) {
-            //TODO: check if there's no other steps in the animation, if so it can't delete it or has to delete the anim
             val index = data.sprites.indexOf(sprite).toUShort()
+            
+            // Now that we've done all the checking, time for the actual replacing
             for (anim in data.animations) {
                 for (step in anim.steps) {
                     if (step.spriteIndex == index) {
-                        //TODO: prompt
                         step.spriteIndex = 0.toUShort()
                     } else if (step.spriteIndex > index) {
                         step.spriteIndex = (step.spriteIndex - 1.toUShort()).toUShort()

--- a/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
@@ -160,7 +160,6 @@ class BRCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BRCAD, i
         if (sprite is Sprite) {
             val index = data.sprites.indexOf(sprite).toUShort()
             
-            // Now that we've done all the checking, time for the actual replacing
             for (anim in data.animations) {
                 for (step in anim.steps) {
                     if (step.spriteIndex == index) {

--- a/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/BRCADEditor.kt
@@ -159,14 +159,14 @@ class BRCADEditor(app: Bread, mainPane: MainPane, dataFile: File, data: BRCAD, i
     override fun removeSprite(sprite: ISprite) {
         if (sprite is Sprite) {
             //TODO: check if there's no other steps in the animation, if so it can't delete it or has to delete the anim
-            val index = data.sprites.indexOf(sprite) as UShort
+            val index = data.sprites.indexOf(sprite).toUShort()
             for (anim in data.animations) {
                 for (step in anim.steps) {
                     if (step.spriteIndex == index) {
                         //TODO: prompt
-                        step.spriteIndex = 0 as UShort
+                        step.spriteIndex = 0.toUShort()
                     } else if (step.spriteIndex > index) {
-                        step.spriteIndex = (step.spriteIndex - 1 as UShort) as UShort
+                        step.spriteIndex = (step.spriteIndex - 1.toUShort()).toUShort()
                     }
                 }
             }

--- a/src/main/kotlin/rhmodding/bread/editor/SpritesTab.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/SpritesTab.kt
@@ -127,9 +127,38 @@ open class SpritesTab<F : IDataModel>(editor: Editor<F>) : EditorSubTab<F>(edito
                                 alert.title = "Remove this sprite?"
                                 alert.headerText = "Remove this sprite?"
                                 alert.contentText = "Are you sure you want to remove this sprite?\nYou won't be able to undo this action."
+
                                 if (alert.showAndWait().get() == ButtonType.OK) {
-                                    editor.removeSprite(currentSprite)
-                                    updateSpriteSpinners(false)
+                                    // Check every step because at this point we don't know if the sprite is used in any anims
+                                    var cancel = false
+                                    val index = data.sprites.indexOf(currentSprite).toUShort()
+                                    for (anim in data.animations) {
+                                        var isbreak = true
+                                        for (step in anim.steps) {
+                                            if (step.spriteIndex == index) {
+                                                val alert2 = Alert(Alert.AlertType.CONFIRMATION).apply {
+                                                    editor.app.addBaseStyleToDialog(dialogPane)
+                                                    title = "Sprite used in animation " + data.animations.indexOf(anim).toString()
+                                                    headerText = "Sprite is currently used in an animation"
+                                                    contentText = "Are you absolutely sure you want to remove this sprite?\nThe animation step(s) will be set to sprite 0 if you do."
+                                                }
+                                                if (alert2.showAndWait().get() == ButtonType.OK) {
+                                                    isbreak = true
+                                                    break
+                                                }
+                                                else {
+                                                    cancel = true
+                                                    break
+                                                }
+                                            }
+                                        }
+                                        if (isbreak || cancel) break
+                                    }
+                                    if (!cancel) {
+                                        editor.removeSprite(currentSprite)
+                                        updateSpriteSpinners(false)
+
+                                    }
                                 }
                             }
                         }

--- a/src/main/kotlin/rhmodding/bread/editor/SpritesTab.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/SpritesTab.kt
@@ -16,7 +16,7 @@ import javafx.scene.layout.*
 import javafx.scene.paint.Color
 import javafx.stage.Modality
 import javafx.stage.Stage
-//import rhmodding.bread.model.bccad.Animation as BCCADAnimation
+import rhmodding.bread.model.bccad.Animation as BCCADAnimation
 import rhmodding.bread.model.IDataModel
 import rhmodding.bread.model.ISprite
 import rhmodding.bread.model.ISpritePart
@@ -132,8 +132,10 @@ open class SpritesTab<F : IDataModel>(editor: Editor<F>) : EditorSubTab<F>(edito
                                         if (step.spriteIndex == index) {
                                             val alert = Alert(Alert.AlertType.CONFIRMATION).apply {
                                                 editor.app.addBaseStyleToDialog(dialogPane)
-                                                //if (anim is BCCADAnimation)
-                                                title = "Sprite used in animation " + data.animations.indexOf(anim).toString()
+                                                if (anim is BCCADAnimation)
+                                                    title = "Sprite used in animation " + anim.name
+                                                else
+                                                    title = "Sprite used in animation " + data.animations.indexOf(anim).toString()
                                                 headerText = "Sprite is currently used in an animation"
                                                 contentText = "Are you absolutely sure you want to remove this sprite?\nThe animation step(s) will be set to sprite 0 if you do."
                                             }

--- a/src/main/kotlin/rhmodding/bread/editor/SpritesTab.kt
+++ b/src/main/kotlin/rhmodding/bread/editor/SpritesTab.kt
@@ -16,6 +16,7 @@ import javafx.scene.layout.*
 import javafx.scene.paint.Color
 import javafx.stage.Modality
 import javafx.stage.Stage
+//import rhmodding.bread.model.bccad.Animation as BCCADAnimation
 import rhmodding.bread.model.IDataModel
 import rhmodding.bread.model.ISprite
 import rhmodding.bread.model.ISpritePart
@@ -122,44 +123,53 @@ open class SpritesTab<F : IDataModel>(editor: Editor<F>) : EditorSubTab<F>(edito
                     children += Button("Remove").apply {
                         setOnAction {
                             if (data.sprites.size > 1) {
-                                val alert = Alert(Alert.AlertType.CONFIRMATION)
-                                editor.app.addBaseStyleToDialog(alert.dialogPane)
-                                alert.title = "Remove this sprite?"
-                                alert.headerText = "Remove this sprite?"
-                                alert.contentText = "Are you sure you want to remove this sprite?\nYou won't be able to undo this action."
-
-                                if (alert.showAndWait().get() == ButtonType.OK) {
-                                    // Check every step because at this point we don't know if the sprite is used in any anims
-                                    var cancel = false
-                                    val index = data.sprites.indexOf(currentSprite).toUShort()
-                                    for (anim in data.animations) {
-                                        var isbreak = true
-                                        for (step in anim.steps) {
-                                            if (step.spriteIndex == index) {
-                                                val alert2 = Alert(Alert.AlertType.CONFIRMATION).apply {
-                                                    editor.app.addBaseStyleToDialog(dialogPane)
-                                                    title = "Sprite used in animation " + data.animations.indexOf(anim).toString()
-                                                    headerText = "Sprite is currently used in an animation"
-                                                    contentText = "Are you absolutely sure you want to remove this sprite?\nThe animation step(s) will be set to sprite 0 if you do."
-                                                }
-                                                if (alert2.showAndWait().get() == ButtonType.OK) {
-                                                    isbreak = true
-                                                    break
-                                                }
-                                                else {
-                                                    cancel = true
-                                                    break
-                                                }
+                                // Check every step because at this point we don't know if the sprite is used in any anims
+                                var cancel = false
+                                var isbreak = false
+                                val index = data.sprites.indexOf(currentSprite).toUShort()
+                                for (anim in data.animations) {
+                                    for (step in anim.steps) {
+                                        if (step.spriteIndex == index) {
+                                            val alert = Alert(Alert.AlertType.CONFIRMATION).apply {
+                                                editor.app.addBaseStyleToDialog(dialogPane)
+                                                //if (anim is BCCADAnimation)
+                                                title = "Sprite used in animation " + data.animations.indexOf(anim).toString()
+                                                headerText = "Sprite is currently used in an animation"
+                                                contentText = "Are you absolutely sure you want to remove this sprite?\nThe animation step(s) will be set to sprite 0 if you do."
+                                            }
+                                            if (alert.showAndWait().get() == ButtonType.OK) {
+                                                isbreak = true
+                                                break
+                                            }
+                                            else {
+                                                cancel = true
+                                                break
                                             }
                                         }
-                                        if (isbreak || cancel) break
                                     }
-                                    if (!cancel) {
+                                    if (isbreak || cancel) break
+                                }
+
+                                if (!cancel) {
+                                    if (!isbreak) {
+                                        // This way, the number of alert boxes is reduced to 1 always
+                                        val alert = Alert(Alert.AlertType.CONFIRMATION).apply {
+                                            editor.app.addBaseStyleToDialog(dialogPane)
+                                            title = "Remove this sprite?"
+                                            headerText = "Remove this sprite?"
+                                            contentText = "Are you sure you want to remove this sprite?\nYou won't be able to undo this action."
+                                        }      
+                                        if (alert.showAndWait().get() == ButtonType.OK) {
+                                            editor.removeSprite(currentSprite)
+                                            updateSpriteSpinners(false)
+                                        }                   
+                                    } else {
                                         editor.removeSprite(currentSprite)
                                         updateSpriteSpinners(false)
-
                                     }
+
                                 }
+
                             }
                         }
                     }

--- a/src/main/kotlin/rhmodding/bread/util/Credits.kt
+++ b/src/main/kotlin/rhmodding/bread/util/Credits.kt
@@ -11,7 +11,8 @@ object Credits {
                 Credit("meuol", "https://www.youtube.com/channel/UCNAUWWq3RKyGDHzBuKgEcPg"),
                 Credit("MF5K", "https://www.youtube.com/user/MrMariofan2020"),
                 Credit("kimbjo", "https://github.com/oddMLan"),
-                Credit("CebolaBros64", "https://github.com/CebolaBros64")
+                Credit("CebolaBros64", "https://github.com/CebolaBros64"),
+                Credit("patataofcourse", "https://github.com/patataofcourse")
                      )
     }
     


### PR DESCRIPTION
Fixes #23. Also adds a small confirmation dialogue when replacing a sprite that is being used in any animations.
![image](https://user-images.githubusercontent.com/29714419/154782739-128a81bd-6b82-400f-834c-281a9c98377e.png)
